### PR TITLE
Convert incoming String value to boolean

### DIFF
--- a/drivers/tv/device.js
+++ b/drivers/tv/device.js
@@ -19,6 +19,9 @@ module.exports = class SmartThingsDeviceTV extends SmartThingsDevice {
             : 'off',
         });
       },
+      async onReport({ value }) {
+        return value === 'on';
+      },
     },
     {
       homeyCapabilityId: 'volume_up',


### PR DESCRIPTION
Solves the issue that the TV state was not synced with Homey due to the fact that the event value was a String and the capability needs an Boolean value