### PR TITLE
Updated devices classes from other to specific classes

### DIFF
--- a/drivers/dryer/driver.compose.json
+++ b/drivers/dryer/driver.compose.json
@@ -14,6 +14,6 @@
     "ru": "Сушилка Samsung",
     "ko": "삼성 건조기"
   },
-  "class": "other",
+  "class": "dryer",
   "capabilities": []
 }

--- a/drivers/oven/driver.compose.json
+++ b/drivers/oven/driver.compose.json
@@ -14,6 +14,6 @@
     "ru": "Духовка Samsung",
     "ko": "삼성 오븐"
   },
-  "class": "other",
+  "class": "oven",
   "capabilities": []
 }

--- a/drivers/refrigerator/driver.compose.json
+++ b/drivers/refrigerator/driver.compose.json
@@ -14,7 +14,7 @@
     "ru": "Холодильник Samsung",
     "ko": "삼성 냉장고"
   },
-  "class": "other",
+  "class": "fridge",
   "capabilities": [],
   "capabilitiesOptions": {
     "measure_temperature.cooler": {

--- a/drivers/washer/driver.compose.json
+++ b/drivers/washer/driver.compose.json
@@ -14,6 +14,6 @@
     "ru": "Стиральная машина Samsung",
     "ko": "삼성 세탁기"
   },
-  "class": "other",
+  "class": "washer",
   "capabilities": []
 }

--- a/lib/SmartThingsDevice.js
+++ b/lib/SmartThingsDevice.js
@@ -74,7 +74,7 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
       this.onStatus(status);
     })
       .then(() => this.setAvailable())
-      .catch(err => this.setUnavailable(err));
+      .catch(err => this.setUnavailable(err).catch(this.error));
   }
 
   onStatus(status) {


### PR DESCRIPTION
Since the app was updated to require Homey v12.0.0, we can update the device classes to their actual classes instead of just 'other'.