### PR TITLE
Include capabilities for ACs

### DIFF
--- a/app.json
+++ b/app.json
@@ -1053,7 +1053,15 @@
         "ko": "삼성 에어컨"
       },
       "class": "airconditioning",
-      "capabilities": [],
+      "capabilities": [
+        "onoff",
+        "measure_temperature",
+        "measure_humidity",
+        "target_temperature",
+        "samsung_airconditioning_mode",
+        "samsung_airconditioning_fan_mode",
+        "samsung_airconditioning_fan_oscillation_mode"
+      ],
       "id": "airconditioning"
     },
     {

--- a/drivers/airconditioning/driver.compose.json
+++ b/drivers/airconditioning/driver.compose.json
@@ -15,5 +15,13 @@
     "ko": "삼성 에어컨"
   },
   "class": "airconditioning",
-  "capabilities": []
+  "capabilities": [
+    "onoff",
+    "measure_temperature",
+    "measure_humidity",
+    "target_temperature",
+    "samsung_airconditioning_mode",
+    "samsung_airconditioning_fan_mode",
+    "samsung_airconditioning_fan_oscillation_mode"
+  ]
 }


### PR DESCRIPTION
If the capabilities are not included in `driver.compose.json` they will only get added once they are reported by the actual device. Added them statically to be available directly after adding a device.