### PR TITLE
Fix capability backfill and multiple report mappings

### DIFF
--- a/lib/SmartThingsDevice.js
+++ b/lib/SmartThingsDevice.js
@@ -29,6 +29,16 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
       deviceId,
     } = await this.getData();
 
+    // Ensure all mapped capabilities exist. Devices paired with older app
+    // versions miss newer capabilities, and button capabilities (onSet-only,
+    // no SmartThings attribute) are never added by incoming reports.
+    for (const capabilityObj of Object.values(this.constructor.CAPABILITIES)) {
+      if (!this.hasCapability(capabilityObj.homeyCapabilityId)) {
+        await this.addCapability(capabilityObj.homeyCapabilityId)
+          .catch(err => this.error(`Error Adding Capability ${capabilityObj.homeyCapabilityId}: ${err.message}`));
+      }
+    }
+
     this.syncStatusIntervalDelay = this.constructor.SYNC_STATUS_INTERVAL;
 
     // Register Device for Webhooks
@@ -102,14 +112,14 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
       for (const [componentId, component] of Object.entries(components)) {
         for (const [capabilityId, capability] of Object.entries(component)) {
           for (const [attributeId, attribute] of Object.entries(capability)) {
-            const capabilityObj = this.constructor.CAPABILITIES.find(capability => {
+            const capabilityObjs = this.constructor.CAPABILITIES.filter(capability => {
               if (capability.smartThingsComponentId !== componentId) return false;
               if (capability.smartThingsCapabilityId !== capabilityId) return false;
               if (capability.smartThingsAttributeId !== attributeId) return false;
               return true;
             });
 
-            if (capabilityObj) {
+            for (const capabilityObj of capabilityObjs) {
               Promise.resolve().then(async () => {
                 const value = capabilityObj.onReport
                   ? await capabilityObj.onReport.call(this, {
@@ -127,7 +137,7 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
 
                   await this.setCapabilityValue(capabilityObj.homeyCapabilityId, value);
                 }
-              }).catch(err => this.error(`Error Calling ${componentId}.${capabilityId}.${attributeId} onReport: ${err.message}`));
+              }).catch(err => this.error(`Error Calling ${componentId}.${capabilityId}.${attributeId} onReport for ${capabilityObj.homeyCapabilityId}: ${err.message}`));
             }
           }
         }
@@ -140,14 +150,14 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
       this.log('onEvent', JSON.stringify(event));
     }
 
-    const capabilityObj = this.constructor.CAPABILITIES.find(capability => {
+    const capabilityObjs = this.constructor.CAPABILITIES.filter(capability => {
       if (capability.smartThingsComponentId !== event.componentId) return false;
       if (capability.smartThingsCapabilityId !== event.capability) return false;
       if (capability.smartThingsAttributeId !== event.attribute) return false;
       return true;
     });
 
-    if (capabilityObj) {
+    for (const capabilityObj of capabilityObjs) {
       Promise.resolve().then(async () => {
         const value = capabilityObj.onReport
           ? await capabilityObj.onReport.call(this, {
@@ -162,7 +172,7 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
 
           await this.setCapabilityValue(capabilityObj.homeyCapabilityId, value);
         }
-      }).catch(err => this.error(`Error Calling ${event.componentId}.${event.capability}.${event.attribute} onReport: ${err.message}`));
+      }).catch(err => this.error(`Error Calling ${event.componentId}.${event.capability}.${event.attribute} onReport for ${capabilityObj.homeyCapabilityId}: ${err.message}`));
     }
   }
 


### PR DESCRIPTION
## Summary
- backfill mapped capabilities during device initialization
- update every Homey capability mapped to the same SmartThings attribute
- include the Homey capability ID in report-processing errors

This is the first focused replacement for #21. It is intentionally limited to the shared capability-reporting behavior.

## Verification
- `git diff --check`
- `homey app build`