### PR TITLE
Fall back to polling when webhooks are not configured

### DIFF
--- a/lib/SmartThingsDevice.js
+++ b/lib/SmartThingsDevice.js
@@ -41,8 +41,10 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
         this.unsetWarning().catch(() => { });
       })
       .catch(err => {
-        this.error(`Register Error: ${err.message}`);
-        this.setWarning(`Device updates may be delayed.\n\n${err.message}`).catch(() => { });
+        if (!err.isWebhookUnconfigured) {
+          this.error(`Register Error: ${err.message}`);
+          this.setWarning(`Device updates may be delayed.\n\n${err.message}`).catch(() => { });
+        }
 
         // Poll every 10s
         this.syncStatusIntervalDelay = 10 * 1000; // 10s

--- a/lib/SmartThingsOAuth2Client.js
+++ b/lib/SmartThingsOAuth2Client.js
@@ -201,6 +201,13 @@ module.exports = class SmartThingsOAuth2Client extends OAuth2Client {
       throw new Error('Please repair this device to get realtime updates.');
     }
 
+    if (!Homey.env.WEBHOOK_ID || typeof Homey.env.WEBHOOK_ID !== 'string') {
+      this._registeredDevices.set(deviceId, { onEvent });
+      const err = new Error('No webhook configured — device will use polling instead.');
+      err.isWebhookUnconfigured = true;
+      throw err;
+    }
+
     await this.createSubscription({
       deviceId,
       installedAppId: token.installed_app_id,


### PR DESCRIPTION
## Summary
- register the device callback even when no webhook ID is configured
- use the existing polling path without showing a misleading webhook warning
- keep normal registration errors visible

This is a focused replacement extracted from #21.

## Verification
- `git diff --check`
- `homey app build`