### PR TITLE
Add reusable SmartThings value parsers

### DIFF
--- a/lib/SmartThingsDevice.js
+++ b/lib/SmartThingsDevice.js
@@ -24,6 +24,47 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
     */
   };
 
+  static getNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+
+  static getPowerConsumptionValue(value, key, divisor = 1) {
+    if (!value || typeof value !== 'object') return undefined;
+
+    const number = this.getNumber(value[key]);
+    if (number === undefined) return undefined;
+
+    return number / divisor;
+  }
+
+  static getBooleanFromOnOff(value) {
+    if (value === 'on') return true;
+    if (value === 'off') return false;
+    return undefined;
+  }
+
+  static getBooleanFromOpenClosed(value) {
+    if (value === 'open') return true;
+    if (value === 'closed') return false;
+    return undefined;
+  }
+
+  static getBooleanFromSmartThings(value) {
+    if (value === true || value === 'true' || value === 'on') return true;
+    if (value === false || value === 'false' || value === 'off') return false;
+    return undefined;
+  }
+
+  getEnumValue(capabilityId, value) {
+    const capability = this.homey.manifest.capabilities?.[capabilityId];
+    if (!capability || !Array.isArray(capability.values)) return value;
+
+    if (capability.values.some(enumValue => enumValue.id === value)) return value;
+
+    this.log(`Ignoring unknown ${capabilityId} value: ${value}`);
+    return undefined;
+  }
+
   async onOAuth2Init() {
     const {
       deviceId,


### PR DESCRIPTION
## Summary
- parse finite numeric report values safely
- parse power-consumption report fields with unit conversion
- normalize common SmartThings boolean values
- ignore unknown enum values instead of passing invalid values to Homey

This small shared prerequisite was extracted from #21 so individual appliance PRs can stay focused.

## Verification
- `git diff --check`
- `homey app build`