### PR TITLE
Add refrigerator controls and consumption reporting

### DIFF
--- a/app.json
+++ b/app.json
@@ -2790,16 +2790,50 @@
         "ko": "삼성 냉장고"
       },
       "class": "fridge",
-      "capabilities": [],
+      "capabilities": [
+        "measure_power",
+        "meter_power",
+        "measure_temperature.cooler",
+        "target_temperature.cooler",
+        "measure_temperature.freezer",
+        "target_temperature.freezer",
+        "alarm_contact",
+        "alarm_contact.freezer",
+        "onoff.icemaker"
+      ],
       "capabilitiesOptions": {
+        "measure_power": {
+          "title": "Power"
+        },
+        "meter_power": {
+          "title": "Energy"
+        },
         "measure_temperature.cooler": {
           "title": "Cooler Temperature"
+        },
+        "target_temperature.cooler": {
+          "title": "Cooler Setpoint",
+          "min": 1,
+          "max": 7,
+          "step": 1
         },
         "measure_temperature.freezer": {
           "title": "Freezer Temperature"
         },
+        "target_temperature.freezer": {
+          "title": "Freezer Setpoint",
+          "min": -23,
+          "max": -15,
+          "step": 1
+        },
         "alarm_contact": {
-          "title": "Door Open"
+          "title": "Cooler Door Open"
+        },
+        "alarm_contact.freezer": {
+          "title": "Freezer Door Open"
+        },
+        "onoff.icemaker": {
+          "title": "Ice Maker"
         }
       },
       "id": "refrigerator"

--- a/drivers/refrigerator/device.js
+++ b/drivers/refrigerator/device.js
@@ -5,11 +5,45 @@ const SmartThingsDevice = require('../../lib/SmartThingsDevice');
 module.exports = class SmartThingsDeviceRefrigerator extends SmartThingsDevice {
 
   static CAPABILITIES = [
+    // Power (W)
+    {
+      homeyCapabilityId: 'measure_power',
+      smartThingsComponentId: 'main',
+      smartThingsCapabilityId: 'powerConsumptionReport',
+      smartThingsAttributeId: 'powerConsumption',
+      async onReport({ value }) {
+        return this.constructor.getPowerConsumptionValue(value, 'power');
+      },
+    },
+    // Energy (kWh) — powerConsumption.energy is in Wh
+    {
+      homeyCapabilityId: 'meter_power',
+      smartThingsComponentId: 'main',
+      smartThingsCapabilityId: 'powerConsumptionReport',
+      smartThingsAttributeId: 'powerConsumption',
+      async onReport({ value }) {
+        return this.constructor.getPowerConsumptionValue(value, 'energy', 1000);
+      },
+    },
     {
       homeyCapabilityId: 'measure_temperature.cooler',
       smartThingsComponentId: 'cooler',
       smartThingsCapabilityId: 'temperatureMeasurement',
       smartThingsAttributeId: 'temperature',
+    },
+    {
+      homeyCapabilityId: 'target_temperature.cooler',
+      smartThingsComponentId: 'cooler',
+      smartThingsCapabilityId: 'thermostatCoolingSetpoint',
+      smartThingsAttributeId: 'coolingSetpoint',
+      async onSet({ value }) {
+        await this.executeCommand({
+          component: 'cooler',
+          capability: 'thermostatCoolingSetpoint',
+          command: 'setCoolingSetpoint',
+          args: [value],
+        });
+      },
     },
     {
       homeyCapabilityId: 'measure_temperature.freezer',
@@ -18,12 +52,51 @@ module.exports = class SmartThingsDeviceRefrigerator extends SmartThingsDevice {
       smartThingsAttributeId: 'temperature',
     },
     {
+      homeyCapabilityId: 'target_temperature.freezer',
+      smartThingsComponentId: 'freezer',
+      smartThingsCapabilityId: 'thermostatCoolingSetpoint',
+      smartThingsAttributeId: 'coolingSetpoint',
+      async onSet({ value }) {
+        await this.executeCommand({
+          component: 'freezer',
+          capability: 'thermostatCoolingSetpoint',
+          command: 'setCoolingSetpoint',
+          args: [value],
+        });
+      },
+    },
+    {
       homeyCapabilityId: 'alarm_contact',
       smartThingsComponentId: 'cooler',
       smartThingsCapabilityId: 'contactSensor',
       smartThingsAttributeId: 'contact',
       async onReport({ value }) {
-        return value === 'open';
+        return this.constructor.getBooleanFromOpenClosed(value);
+      },
+    },
+    {
+      homeyCapabilityId: 'alarm_contact.freezer',
+      smartThingsComponentId: 'freezer',
+      smartThingsCapabilityId: 'contactSensor',
+      smartThingsAttributeId: 'contact',
+      async onReport({ value }) {
+        return this.constructor.getBooleanFromOpenClosed(value);
+      },
+    },
+    {
+      homeyCapabilityId: 'onoff.icemaker',
+      smartThingsComponentId: 'icemaker',
+      smartThingsCapabilityId: 'switch',
+      smartThingsAttributeId: 'switch',
+      async onSet({ value }) {
+        await this.executeCommand({
+          component: 'icemaker',
+          capability: 'switch',
+          command: value ? 'on' : 'off',
+        });
+      },
+      async onReport({ value }) {
+        return this.constructor.getBooleanFromOnOff(value);
       },
     },
   ];

--- a/drivers/refrigerator/driver.compose.json
+++ b/drivers/refrigerator/driver.compose.json
@@ -15,16 +15,50 @@
     "ko": "삼성 냉장고"
   },
   "class": "fridge",
-  "capabilities": [],
+  "capabilities": [
+    "measure_power",
+    "meter_power",
+    "measure_temperature.cooler",
+    "target_temperature.cooler",
+    "measure_temperature.freezer",
+    "target_temperature.freezer",
+    "alarm_contact",
+    "alarm_contact.freezer",
+    "onoff.icemaker"
+  ],
   "capabilitiesOptions": {
+    "measure_power": {
+      "title": "Power"
+    },
+    "meter_power": {
+      "title": "Energy"
+    },
     "measure_temperature.cooler": {
       "title": "Cooler Temperature"
+    },
+    "target_temperature.cooler": {
+      "title": "Cooler Setpoint",
+      "min": 1,
+      "max": 7,
+      "step": 1
     },
     "measure_temperature.freezer": {
       "title": "Freezer Temperature"
     },
+    "target_temperature.freezer": {
+      "title": "Freezer Setpoint",
+      "min": -23,
+      "max": -15,
+      "step": 1
+    },
     "alarm_contact": {
-      "title": "Door Open"
+      "title": "Cooler Door Open"
+    },
+    "alarm_contact.freezer": {
+      "title": "Freezer Door Open"
+    },
+    "onoff.icemaker": {
+      "title": "Ice Maker"
     }
   }
 }

--- a/drivers/refrigerator/driver.js
+++ b/drivers/refrigerator/driver.js
@@ -2,7 +2,7 @@
 
 const SmartThingsDriver = require('../../lib/SmartThingsDriver');
 
-module.exports = class SmartThingsDriverWasher extends SmartThingsDriver {
+module.exports = class SmartThingsDriverRefrigerator extends SmartThingsDriver {
 
   onPairFilterDevice(device) {
     this.log('onPairFilterDevice', device.deviceTypeName);

--- a/lib/SmartThingsDevice.js
+++ b/lib/SmartThingsDevice.js
@@ -24,6 +24,47 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
     */
   };
 
+  static getNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+
+  static getPowerConsumptionValue(value, key, divisor = 1) {
+    if (!value || typeof value !== 'object') return undefined;
+
+    const number = this.getNumber(value[key]);
+    if (number === undefined) return undefined;
+
+    return number / divisor;
+  }
+
+  static getBooleanFromOnOff(value) {
+    if (value === 'on') return true;
+    if (value === 'off') return false;
+    return undefined;
+  }
+
+  static getBooleanFromOpenClosed(value) {
+    if (value === 'open') return true;
+    if (value === 'closed') return false;
+    return undefined;
+  }
+
+  static getBooleanFromSmartThings(value) {
+    if (value === true || value === 'true' || value === 'on') return true;
+    if (value === false || value === 'false' || value === 'off') return false;
+    return undefined;
+  }
+
+  getEnumValue(capabilityId, value) {
+    const capability = this.homey.manifest.capabilities?.[capabilityId];
+    if (!capability || !Array.isArray(capability.values)) return value;
+
+    if (capability.values.some(enumValue => enumValue.id === value)) return value;
+
+    this.log(`Ignoring unknown ${capabilityId} value: ${value}`);
+    return undefined;
+  }
+
   async onOAuth2Init() {
     const {
       deviceId,


### PR DESCRIPTION
## Summary
- add cooler and freezer temperature/setpoint capabilities
- report cooler and freezer door contacts
- add ice-maker control
- add power and energy reporting

Includes #24 as its shared prerequisite; once #24 merges, this PR will contain only the refrigerator commit set. Extracted from #21.

## Verification
- `git diff --check`
- `homey app build`