### PR TITLE
Add TV power and energy reporting

### DIFF
--- a/app.json
+++ b/app.json
@@ -2998,7 +2998,9 @@
         "volume_up",
         "volume_down",
         "channel_up",
-        "channel_down"
+        "channel_down",
+        "measure_power",
+        "meter_power"
       ],
       "id": "tv"
     },

--- a/drivers/tv/device.js
+++ b/drivers/tv/device.js
@@ -4,6 +4,10 @@ const SmartThingsDevice = require('../../lib/SmartThingsDevice');
 
 module.exports = class SmartThingsDeviceTV extends SmartThingsDevice {
 
+  // Samsung TV energy reports are not reliably pushed as webhook events. Poll
+  // often enough to receive the rolling usage values that SmartThings exposes.
+  static SYNC_STATUS_INTERVAL = 5 * 60 * 1000; // 5 min
+
   static CAPABILITIES = [
     {
       homeyCapabilityId: 'onoff',
@@ -71,7 +75,88 @@ module.exports = class SmartThingsDeviceTV extends SmartThingsDevice {
         });
       },
     },
+    // Power (W)
+    {
+      homeyCapabilityId: 'measure_power',
+      smartThingsComponentId: 'main',
+      smartThingsCapabilityId: 'powerConsumptionReport',
+      smartThingsAttributeId: 'powerConsumption',
+      async onReport({ value }) {
+        return this.getPowerValue(value);
+      },
+    },
+    // Energy (kWh) — powerConsumption.energy is in Wh
+    {
+      homeyCapabilityId: 'meter_power',
+      smartThingsComponentId: 'main',
+      smartThingsCapabilityId: 'powerConsumptionReport',
+      smartThingsAttributeId: 'powerConsumption',
+      async onReport({ value }) {
+        return this.getEnergyValue(value);
+      },
+    },
   ];
+
+  getPowerValue(value) {
+    const reportedPower = this.constructor.getPowerConsumptionValue(value, 'power');
+    const reportedEnergy = this.constructor.getPowerConsumptionValue(value, 'energy');
+    const deltaEnergy = this.constructor.getPowerConsumptionValue(value, 'deltaEnergy');
+
+    this.log('TV powerConsumptionReport', JSON.stringify(value));
+
+    if (reportedPower && reportedPower > 0) return reportedPower;
+
+    const start = Date.parse(value?.start);
+    const end = Date.parse(value?.end);
+    const durationHours = (end - start) / (60 * 60 * 1000);
+    if (deltaEnergy && deltaEnergy > 0 && Number.isFinite(durationHours) && durationHours > 0) {
+      return deltaEnergy / durationHours;
+    }
+
+    if (reportedEnergy === undefined) return reportedPower;
+
+    const now = Date.now();
+    const previousSample = this._powerConsumptionSample;
+    this._powerConsumptionSample = {
+      energy: reportedEnergy,
+      time: now,
+    };
+
+    if (!previousSample) return reportedPower;
+
+    const energyDelta = reportedEnergy - previousSample.energy;
+    const timeDeltaHours = (now - previousSample.time) / (60 * 60 * 1000);
+    if (energyDelta <= 0 || timeDeltaHours <= 0) return reportedPower;
+
+    return energyDelta / timeDeltaHours;
+  }
+
+  getEnergyValue(value) {
+    this._energyUpdate = (this._energyUpdate || Promise.resolve())
+      .then(() => this.updateEnergyValue(value));
+    return this._energyUpdate;
+  }
+
+  async updateEnergyValue(value) {
+    const reportedEnergy = this.constructor.getPowerConsumptionValue(value, 'energy');
+    if (reportedEnergy && reportedEnergy > 0) {
+      this._lastMeterPower = reportedEnergy / 1000;
+      return this._lastMeterPower;
+    }
+
+    const deltaEnergy = this.constructor.getPowerConsumptionValue(value, 'deltaEnergy');
+    const end = typeof value?.end === 'string' ? value.end : undefined;
+    const currentMeterValue = this.constructor.getNumber(this.getCapabilityValue('meter_power')) || 0;
+    const previousMeterValue = this._lastMeterPower ?? currentMeterValue;
+
+    if (!end || !deltaEnergy || deltaEnergy <= 0) return previousMeterValue;
+
+    if (this.getStoreValue('tvPowerConsumptionEnd') === end) return previousMeterValue;
+
+    await this.setStoreValue('tvPowerConsumptionEnd', end);
+    this._lastMeterPower = previousMeterValue + (deltaEnergy / 1000);
+    return this._lastMeterPower;
+  }
 
   // We haven't found a TV that supports the `samsungTV` capability yet.
   // onFlowActionShowMessage = async ({ message }) => {

--- a/drivers/tv/driver.compose.json
+++ b/drivers/tv/driver.compose.json
@@ -20,6 +20,8 @@
     "volume_up",
     "volume_down",
     "channel_up",
-    "channel_down"
+    "channel_down",
+    "measure_power",
+    "meter_power"
   ]
 }

--- a/lib/SmartThingsDevice.js
+++ b/lib/SmartThingsDevice.js
@@ -24,6 +24,47 @@ module.exports = class SmartThingsDevice extends OAuth2Device {
     */
   };
 
+  static getNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+
+  static getPowerConsumptionValue(value, key, divisor = 1) {
+    if (!value || typeof value !== 'object') return undefined;
+
+    const number = this.getNumber(value[key]);
+    if (number === undefined) return undefined;
+
+    return number / divisor;
+  }
+
+  static getBooleanFromOnOff(value) {
+    if (value === 'on') return true;
+    if (value === 'off') return false;
+    return undefined;
+  }
+
+  static getBooleanFromOpenClosed(value) {
+    if (value === 'open') return true;
+    if (value === 'closed') return false;
+    return undefined;
+  }
+
+  static getBooleanFromSmartThings(value) {
+    if (value === true || value === 'true' || value === 'on') return true;
+    if (value === false || value === 'false' || value === 'off') return false;
+    return undefined;
+  }
+
+  getEnumValue(capabilityId, value) {
+    const capability = this.homey.manifest.capabilities?.[capabilityId];
+    if (!capability || !Array.isArray(capability.values)) return value;
+
+    if (capability.values.some(enumValue => enumValue.id === value)) return value;
+
+    this.log(`Ignoring unknown ${capabilityId} value: ${value}`);
+    return undefined;
+  }
+
   async onOAuth2Init() {
     const {
       deviceId,


### PR DESCRIPTION
## Summary
- add TV power and energy capabilities
- consume SmartThings power-consumption reports
- derive average power when only energy deltas are available
- persist delta timestamps to avoid counting the same interval twice

Includes #24 as its shared prerequisite; once #24 merges, this PR will contain only the TV commit set. Extracted from #21.

## Verification
- `git diff --check`
- `homey app build`