### PR TITLE
Extend the washer widget

### DIFF
--- a/app.json
+++ b/app.json
@@ -3066,9 +3066,20 @@
   "widgets": {
     "widget-washer": {
       "name": {
-        "en": "Washer"
+        "en": "Washer",
+        "nl": "Wasmachine",
+        "de": "Waschmaschine",
+        "fr": "Lave-linge",
+        "es": "Lavadora",
+        "it": "Lavatrice",
+        "no": "Vaskemaskin",
+        "sv": "Tvättmaskin",
+        "da": "Vaskemaskine",
+        "pl": "Pralka",
+        "ru": "Стиральная машина",
+        "ko": "세탁기"
       },
-      "height": 140,
+      "height": 240,
       "settings": [],
       "devices": {
         "type": "app",

--- a/widgets/widget-washer/api.js
+++ b/widgets/widget-washer/api.js
@@ -2,28 +2,40 @@
 
 module.exports = {
   async getWasherState({ homey, query }) {
-
     const selectedDeviceId = query.deviceId;
 
     const driver = await homey.drivers.getDriver('washer');
     const devices = driver.getDevices();
+    const device = devices.find(d => d.getId() === selectedDeviceId);
 
-    const selectedDevice = devices.find(device => device.getId() === selectedDeviceId);
+    if (!device) throw new Error('Device not found');
 
-    const name = await selectedDevice.getName();
-    let state = await selectedDevice.getCapabilityValue('samsung_washer_current_job_state');
-    let progress = await selectedDevice.getCapabilityValue('samsung_washer_progress_percentage');
-    let remainingTime = await selectedDevice.getCapabilityValue('samsung_washer_progress_remaining_time');
+    const name = await device.getName();
+    let state = device.getCapabilityValue('samsung_washer_current_job_state');
+    let progress = device.getCapabilityValue('samsung_washer_progress_percentage');
+    let remainingTime = device.getCapabilityValue('samsung_washer_progress_remaining_time');
+    const power = device.getCapabilityValue('measure_power');
+    const energy = device.getCapabilityValue('meter_power');
+    const water = device.getCapabilityValue('meter_water');
+    const remoteEnabled = device.getCapabilityValue('samsung_washer_remote_control_enabled');
+    const detergent = device.getCapabilityValue('samsung_washer_auto_detergent_status');
+    const softener = device.getCapabilityValue('samsung_washer_auto_softener_status');
 
-    if (state == 'none') state = 'off';
-    if (state == 'off') remainingTime = '-';
-    if (progress == 1) progress = 0;
+    if (state === 'none') state = 'off';
+    if (state === 'off') remainingTime = '-';
+    if (progress === 1) progress = 0;
 
     return {
       name,
       state,
-      progress,
+      progress: state === 'off' ? 0 : (progress || 0),
       remainingTime,
+      power: typeof power === 'number' ? power : null,
+      energy: typeof energy === 'number' ? energy : null,
+      water: typeof water === 'number' ? (water * 1000) : null,
+      remoteEnabled: remoteEnabled === true,
+      detergent: detergent || null,
+      softener: softener || null,
     };
   },
 };

--- a/widgets/widget-washer/public/index.html
+++ b/widgets/widget-washer/public/index.html
@@ -1,119 +1,156 @@
 <html>
-  <head>
-    <link href="./style.css" rel="stylesheet">
-  </head>
+<head>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body class="homey-widget-full">
+<div id="app">
+  <div class="panel is-washer">
+    <div class="p-hdr">
+      <span class="dev-name" id="name">—</span>
+      <span class="remote remote-w" id="remote" style="display:none">Remote</span>
+    </div>
 
-  <body class="homey-widget-full">
-    <h2 class="device-name homey-text-bold" id="deviceName">[name]</h2>
-    <div class="main-container background">
-        <div class="washer-info-panel">
-          <div class="status-container">
-            <div class="status-row">
-              <div class="status-info">
-                <span class="status-value homey-text-medium homey-color-text" id="currentJobState">[State]</span>
-                <div class="time-value homey-text-medium homey-color-text" id="remainingTime">
-                  <span id="timeHours">00</span><span class="time-colon">:</span><span id="timeMinutes">00</span>
-                </div>
-              </div>
-              <div class="progress-container">
-                <svg class="progress-circle" width="64" height="64" viewBox="0 0 48 48">
-                  <circle class="progress-circle-bg" cx="24" cy="24" r="20"/>
-                  <circle class="progress-circle-path" cx="24" cy="24" r="20"/>
-                </svg>
-                <div class="progress-text homey-color-text" id="progressText">0%</div>
-              </div>
-            </div>
-          </div>
+    <div class="p-body">
+      <div class="ring-wrap">
+        <svg class="ring-svg" viewBox="0 0 48 48">
+          <circle class="ring-bg" cx="24" cy="24" r="21"/>
+          <circle class="ring-main rp-w" id="prog" cx="24" cy="24" r="21"/>
+        </svg>
+        <span class="ring-pct" id="pct">—</span>
+      </div>
+      <div class="p-info">
+        <div class="row"><span class="lbl">Status</span><span class="val" id="stat">—</span></div>
+        <div class="row"><span class="lbl">Left</span><span class="val tval" id="time">—</span></div>
+        <div class="row"><span class="lbl">Done</span><span class="val" id="done">—</span></div>
       </div>
     </div>
 
-    <script type="text/javascript">
-      function onHomeyReady(Homey) {
-        Homey.ready({ height: 150 });
+    <div class="p-stats">
+      <div class="stat stat-power">
+        <span class="stat-val"><span id="pw-v">—</span><span class="stat-unit">W</span></span>
+        <span class="stat-lbl">Power</span>
+      </div>
+      <div class="stat stat-energy">
+        <span class="stat-val"><span id="en-v">—</span><span class="stat-unit">kWh</span></span>
+        <span class="stat-lbl">Energy</span>
+      </div>
+      <div class="stat stat-water" id="wt-wrap" style="display:none">
+        <span class="stat-val"><span id="wt-v">—</span><span class="stat-unit">L</span></span>
+        <span class="stat-lbl">Water</span>
+      </div>
+    </div>
 
-        const $deviceName = document.getElementById('deviceName');
-        const $currentJobState = document.getElementById('currentJobState');
-        const $remainingTime = document.getElementById('remainingTime');
-        const $progressCircle = document.querySelector('.progress-circle-path');
-        const $progressCircleContainer = document.querySelector('.progress-circle');
-        const $progressText = document.getElementById('progressText');
-        const $selectedDeviceId = Homey.getDeviceIds()[0];
+    <div class="p-cons" id="cons" style="display:none">
+      <span class="c-badge" id="det" style="display:none">
+        <span class="c-dot" id="det-dot"></span>
+        <span class="c-name">Det</span>
+        <span class="c-val" id="det-val">—</span>
+      </span>
+      <span class="c-badge" id="sof" style="display:none">
+        <span class="c-dot" id="sof-dot"></span>
+        <span class="c-name">Sof</span>
+        <span class="c-val" id="sof-val">—</span>
+      </span>
+    </div>
+  </div>
+</div>
 
-        // Calculate stroke-dasharray and stroke-dashoffset
-        const radius = 20;
-        const circumference = 2 * Math.PI * radius;
-        $progressCircle.style.strokeDasharray = circumference;
+<script>
+function onHomeyReady(Homey) {
+  Homey.ready({ height: 240 });
 
-        // Function to update progress circle
-        function updateProgress(progress) {
-          // Adjust offset calculation to start from bottom
-          const offset = (((100 - progress) / 100) * circumference);
-          $progressCircle.style.strokeDashoffset = offset;
-          
-          // Update progress text
-          $progressText.textContent = progress < 2 ? '-' : `${Math.round(progress)}%`;
-          
-          // Add or remove active class based on progress
-          if (progress > 1) {
-            $progressCircleContainer.classList.add('active');
+  const C_MAIN = 2 * Math.PI * 21;
+  const deviceId = Homey.getDeviceIds()[0];
+
+  function setRing(el, C, pct) {
+    el.style.strokeDasharray = C;
+    el.style.strokeDashoffset = C * (1 - Math.min(1, Math.max(0, pct)));
+  }
+
+  function finishTime(r) {
+    if (!r || r === '-') return '—';
+    const p = r.split(':');
+    const h = parseInt(p[0], 10), m = parseInt(p[1], 10);
+    if (isNaN(h) || isNaN(m)) return '—';
+    const d = new Date();
+    d.setHours(d.getHours() + h);
+    d.setMinutes(d.getMinutes() + m);
+    return String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0');
+  }
+
+  function fmtPower(w) {
+    if (w == null) return '—';
+    return w >= 1000 ? (w / 1000).toFixed(1) + 'k' : String(Math.round(w));
+  }
+
+  function consStatus(val) {
+    const map = { normal: ['OK', 'c-ok'], low: ['Low', 'c-low'], empty: ['Empty', 'c-empty'], error: ['Err', 'c-empty'] };
+    return map[val] || [val || '—', 'c-ok'];
+  }
+
+  function refresh() {
+    if (!deviceId) return;
+    Homey.api('GET', '/?deviceId=' + deviceId)
+      .then(info => {
+        document.getElementById('name').textContent = info.name || '—';
+
+        const rem = document.getElementById('remote');
+        rem.style.display = info.remoteEnabled ? 'inline-block' : 'none';
+
+        const state = (info.state === 'none' ? 'off' : info.state) || 'off';
+        const isActive = state !== 'off';
+        const prog = isActive ? (info.progress || 0) : 0;
+        const pct = prog < 2 ? 0 : prog;
+
+        const progEl = document.getElementById('prog');
+        progEl.classList.toggle('is-idle', !isActive);
+        setRing(progEl, C_MAIN, pct / 100);
+        document.getElementById('pct').textContent = pct < 2 ? '—' : Math.round(pct) + '%';
+
+        document.getElementById('stat').textContent =
+          Homey.__('samsung_washer_current_job_state.' + state) || state || '—';
+
+        const rem_time = isActive ? (info.remainingTime || '—') : '—';
+        const timeEl = document.getElementById('time');
+        timeEl.textContent = rem_time;
+        timeEl.classList.toggle('tv-w', isActive);
+        document.getElementById('done').textContent = isActive ? finishTime(rem_time) : '—';
+
+        document.getElementById('pw-v').textContent = fmtPower(info.power);
+        document.getElementById('en-v').textContent = info.energy != null ? info.energy.toFixed(2) : '—';
+
+        const wtWrap = document.getElementById('wt-wrap');
+        if (info.water != null) {
+          wtWrap.style.display = 'flex';
+          document.getElementById('wt-v').textContent = Math.round(info.water);
+        } else {
+          wtWrap.style.display = 'none';
+        }
+
+        const consEl = document.getElementById('cons');
+        const hasDet = info.detergent != null;
+        const hasSof = info.softener != null;
+        consEl.style.display = (hasDet || hasSof) ? 'flex' : 'none';
+
+        [['det', info.detergent], ['sof', info.softener]].forEach(([key, val]) => {
+          const el = document.getElementById(key);
+          if (!el) return;
+          if (val != null) {
+            el.style.display = 'flex';
+            const [label, cls] = consStatus(val);
+            document.getElementById(key + '-dot').className = 'c-dot ' + cls;
+            document.getElementById(key + '-val').textContent = label;
           } else {
-            $progressCircleContainer.classList.remove('active');
+            el.style.display = 'none';
           }
-        }
+        });
+      })
+      .catch(err => console.error('Failed to refresh washer widget:', err));
+  }
 
-        // Function to get readable status text
-        function getStatusText(value) {
-          return Homey.__(`samsung_washer_current_job_state.${value}`) || value || 'Unknown';
-        }
-
-        function updateWasherInfo() {
-          // Get washer state from root endpoint
-          Homey.api('GET', `/?deviceId=${$selectedDeviceId}`)
-            .then((washerInfo) => {
-
-              //test
-              // washerInfo.progress = 13;
-              // washerInfo.remainingTime = '01:14';
-              // washerInfo.state = 'wash'; 
-              // washerInfo.name = 'Samsung Washer';
-              //
-
-              // Update device name
-              $deviceName.textContent = washerInfo.name || 'Samsung Washer';
-              
-              // Update job state
-              $currentJobState.textContent = getStatusText(washerInfo.state);
-              
-              // Update progress
-              updateProgress(washerInfo.progress || 0);
-              
-              // Update remaining time
-              if (washerInfo.remainingTime === '-') {
-                document.getElementById('timeHours').textContent = '-';
-                document.getElementById('timeMinutes').textContent = '';
-                document.querySelector('.time-colon').style.display = 'none';
-              } else {
-                const [hours, minutes] = (washerInfo.remainingTime || '00:00').split(':');
-                document.getElementById('timeHours').textContent = hours;
-                document.getElementById('timeMinutes').textContent = minutes;
-                document.querySelector('.time-colon').style.display = 'inline-block';
-              }
-            })
-            .catch(error => {
-              console.error('Error fetching washer data:', error);
-              $deviceName.textContent = 'Samsung Washer';
-              $currentJobState.textContent = 'Error loading';
-              document.getElementById('timeHours').textContent = '-';
-              document.getElementById('timeMinutes').textContent = '';
-              document.querySelector('.time-colon').style.display = 'none';
-              updateProgress(0);
-            });
-        }
-
-        // Update immediately and then every 5 seconds
-        updateWasherInfo();
-        setInterval(updateWasherInfo, 5000);
-      }
-    </script>
-  </body>
+  refresh();
+  setInterval(refresh, 5000);
+}
+</script>
+</body>
 </html>

--- a/widgets/widget-washer/public/style.css
+++ b/widgets/widget-washer/public/style.css
@@ -1,193 +1,228 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  width: 100%;
+}
+
 body {
+  font-family: var(--homey-text-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  background: var(--homey-background-color, #101820);
+  color: var(--homey-text-color, #fff);
   overflow: hidden;
-  padding: var(--homey-su-2);
-  margin: 0;
-  font-family: var(--homey-text-font-family);
-  position: relative;
-  color: var(--homey-color-text);
 }
 
-.device-name {
-  position: absolute;
-  top: var(--homey-su-2);
-  left: var(--homey-su-3);
-  margin: 0;
-  padding: var(--homey-su-2) var(--homey-su-4);
-  white-space: normal;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-  hyphens: auto;
-  line-height: 1.2;
-  max-height: 2.4em;
-  z-index: 10;
-  text-align: left;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5),
-               -1px -1px 0 rgba(255, 255, 255, 0.2);
-  font-weight: bold;
-  color: rgb(255, 255, 255);
-  letter-spacing: 0.5px;
-}
-
-.main-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+#app {
   display: flex;
-  align-items: stretch;
-  gap: 10px;
-  overflow: hidden;
+  height: 100%;
+  width: 100%;
+  padding: var(--homey-su-3, 12px) var(--homey-su-4, 16px);
 }
 
-.main-container.background {
-  background-image: url('washer.png');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
-.washer-info-panel {
-  background: rgba(0, 0, 0, 0.5);
-  border-radius: 12px;
-  padding: var(--homey-su-4);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-  height: 60%;
-  overflow: hidden;
-  margin-top: 40px;
-  margin-left: var(--homey-su-4);
-  color: var(--homey-color-text);
-}
-
-.status-container {
+.panel {
+  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: 100%;
-  height: 100%;
-  gap: var(--homey-su-4);
+  gap: var(--homey-su-3, 12px);
+  min-width: 0;
+  max-width: 420px;
+  padding-left: var(--homey-su-3, 12px);
+  border-left: 3px solid var(--homey-color-blue, #2d9cdb);
 }
 
-.status-row {
+/* ── Header ── */
+.p-hdr {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  width: 100%;
-  gap: var(--homey-su-3);
+  justify-content: space-between;
+  gap: 4px;
 }
 
-.status-info {
-  display: flex;
-  flex-direction: column;
-  gap: var(--homey-su-2);
-  min-width: 0;
-}
-
-.status-value,
-.time-value {
-  font-size: 1.2em;
-  font-weight: 500;
-  border-radius: 6px;
-  white-space: normal;
+.dev-name {
+  font-size: 13px;
+  font-weight: var(--homey-font-weight-bold, 700);
+  color: var(--homey-text-color, rgba(255,255,255,0.95));
+  white-space: nowrap;
   overflow: hidden;
-  min-width: 0;
+  text-overflow: ellipsis;
+  flex: 1;
+  letter-spacing: 0.2px;
 }
 
-.status-value {
-  word-break: break-word;
-  line-height: 1.2;
+.remote {
+  font-size: 9px;
+  font-weight: var(--homey-font-weight-bold, 600);
+  letter-spacing: 0.4px;
+  padding: 3px 7px;
+  border-radius: var(--homey-border-radius-small, 8px);
+  white-space: nowrap;
+  flex-shrink: 0;
+  color: var(--homey-text-color-blue, #2d9cdb);
+  background: rgba(45,156,219,0.14);
+  background: color-mix(in srgb, var(--homey-color-blue, #2d9cdb) 14%, transparent);
+  border: 1px solid rgba(45,156,219,0.3);
+  border: 1px solid color-mix(in srgb, var(--homey-color-blue, #2d9cdb) 30%, transparent);
 }
 
-@keyframes pulse {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.05);
-    opacity: 0.8;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
+/* ── Body ── */
+.p-body {
+  display: flex;
+  align-items: center;
+  gap: var(--homey-su-3, 12px);
 }
 
-.progress-container {
+.ring-wrap {
   position: relative;
-  width: 64px;
-  height: 64px;
+  width: 64px; height: 64px;
   flex-shrink: 0;
 }
 
-.progress-circle {
-  transform: rotate(90deg);
+.ring-svg {
+  width: 64px; height: 64px;
+  transform: rotate(-90deg);
   transform-origin: 50% 50%;
-  width: 64px;
-  height: 64px;
+  display: block;
 }
 
-.progress-circle.active {
-  animation: pulse 2s ease-in-out infinite;
-}
+.ring-bg { fill: none; stroke: var(--homey-line-color-light, rgba(128,128,128,0.18)); stroke-width: 3.5; }
 
-.progress-circle-bg {
+.ring-main {
   fill: none;
-  stroke: rgba(0, 0, 0, 0.1);
-  stroke-width: 4;
-}
-
-.progress-circle-path {
-  fill: none;
-  stroke: var(--homey-color-primary, #15bfff);
-  stroke-width: 4;
+  stroke: var(--homey-color-blue, #2d9cdb);
+  stroke-width: 3.5;
   stroke-linecap: round;
-  transition: stroke-dashoffset 0.3s ease;
+  transition: stroke-dashoffset 0.6s ease, opacity 0.3s ease;
+  filter: drop-shadow(0 0 4px rgba(45,156,219,0.5));
 }
+.ring-main.is-idle { opacity: 0.25; filter: none; }
 
-.progress-text {
+.ring-pct {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  top: 50%; left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: var(--homey-font-weight-bold, 700);
+  color: var(--homey-text-color, #fff);
+  pointer-events: none;
 }
 
-@keyframes colonPulse {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.3;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-.time-colon {
-  animation: colonPulse 1s ease-in-out infinite;
-  display: inline-block;
-  width: 0.3em;
-  text-align: center;
-}
-
-.time-value {
+/* ── Info ── */
+.p-info {
+  flex: 1;
   display: flex;
-  align-items: center;
-  gap: 2px;
-  font-variant-numeric: tabular-nums;
-  font-size: 1.2em;
-  font-weight: 500;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.lbl {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--homey-text-color-light, rgba(128,128,128,0.7));
+  flex-shrink: 0;
+  width: 34px;
+}
+
+.val {
+  font-size: 12px;
+  font-weight: var(--homey-font-weight-medium, 600);
+  color: var(--homey-text-color, rgba(255,255,255,0.9));
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.tval {
+  font-size: 15px;
+  font-weight: var(--homey-font-weight-bold, 700);
+  font-variant-numeric: tabular-nums;
+  color: var(--homey-text-color-light, rgba(128,128,128,0.6));
+}
+.tval.tv-w { color: var(--homey-text-color-blue, #2d9cdb); }
 
+/* ── Stat chips ── */
+.p-stats {
+  display: flex;
+  gap: var(--homey-su-2, 8px);
+}
 
+.stat {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 9px;
+  border-radius: var(--homey-border-radius-default, 10px);
+  background: var(--homey-color-mono-100, rgba(128,128,128,0.08));
+}
 
+.stat-val {
+  font-size: 14px;
+  font-weight: var(--homey-font-weight-bold, 700);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.stat-unit {
+  font-size: 9px;
+  font-weight: var(--homey-font-weight-medium, 500);
+  margin-left: 2px;
+  color: var(--homey-text-color-light, rgba(128,128,128,0.7));
+}
+.stat-lbl {
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--homey-text-color-light, rgba(128,128,128,0.6));
+}
+.stat-power  .stat-val { color: var(--homey-color-warning, #f2c94c); }
+.stat-energy .stat-val { color: var(--homey-color-success, #27ae60); }
+.stat-water  .stat-val { color: #22c7b8; }
 
+/* ── Consumables ── */
+.p-cons {
+  display: flex;
+  gap: 6px;
+}
 
+.c-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border-radius: var(--homey-border-radius-small, 999px);
+  padding: 4px 9px;
+  background: var(--homey-color-mono-100, rgba(128,128,128,0.08));
+  border: 1px solid var(--homey-line-color-light, rgba(128,128,128,0.12));
+}
 
+.c-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.c-ok    { background: var(--homey-color-success, #27ae60); }
+.c-low   { background: var(--homey-color-warning, #f2c94c); }
+.c-empty { background: var(--homey-color-danger, #eb5757); }
 
+.c-name {
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--homey-text-color-light, rgba(128,128,128,0.7));
+}
+
+.c-val {
+  font-size: 9px;
+  font-weight: var(--homey-font-weight-medium, 600);
+  color: var(--homey-text-color, rgba(255,255,255,0.85));
+}

--- a/widgets/widget-washer/widget.compose.json
+++ b/widgets/widget-washer/widget.compose.json
@@ -1,8 +1,19 @@
 {
   "name": {
-    "en": "Washer"
+    "en": "Washer",
+    "nl": "Wasmachine",
+    "de": "Waschmaschine",
+    "fr": "Lave-linge",
+    "es": "Lavadora",
+    "it": "Lavatrice",
+    "no": "Vaskemaskin",
+    "sv": "Tvättmaskin",
+    "da": "Vaskemaskine",
+    "pl": "Pralka",
+    "ru": "Стиральная машина",
+    "ko": "세탁기"
   },
-  "height": 140,
+  "height": 240,
   "settings": [],
   "devices": {
     "type": "app",


### PR DESCRIPTION
## Summary
- refresh the existing washer widget layout
- show cycle progress, remaining time, power, energy, water, and consumable status
- log API failures instead of silently retaining stale values

Designed for the washer capabilities in #25. Extracted from #21.

## Verification
- `git diff --check`
- `homey app build`